### PR TITLE
feat(ldap): add paginated search using Virtual List View and Server Side Sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,22 @@ async def main():
         async for entry in conn.search_dn(search_base, Scope.Subtree, '(&(uid=*)(objectClass=person))'):
             print(entry.dn)
 
-        # search paginated
+        # search paginated via SimplePagedResult
+        async for entry in conn.search_paged(
+            search_base,
+            Scope.Subtree,
+            '(&(uid=*)(objectClass=person))',
+            page_size=10,
+        ):
+            print(entry.dn, entry.attr, entry.page)
+
+        # search paginated via VirtualListView + ServerSideSorting
         async for entry in conn.search_paginated(
             search_base,
             Scope.Subtree,
             '(&(uid=*)(objectClass=person))',
             page_size=10,
+            sorting=[('uid', 'caseIgnoreOrderingMatch', False)]
         ):
             print(entry.dn, entry.attr, entry.page)
 

--- a/docs/examples/search.py
+++ b/docs/examples/search.py
@@ -26,14 +26,33 @@ async def ldap_search_examples():
         ):
             print(entry.dn)
 
-        # search paginated
-        async for entry in conn.search_paginated(
+        # search paginated via SimplePagedResult
+        async for entry in conn.search_paged(
             search_base,
-            Scope.SUBTREE,
+            Scope.Subtree,
             '(&(uid=*)(objectClass=person))',
             page_size=10,
         ):
+            print(entry.dn, entry.attr, entry.page)
+
+        # all of the previous searches allow specifying the ServerSideSorting control:
+        for entry in await conn.search(
+            search_base,
+            Scope.SUBTREE,
+            '(&(uid=*)(objectClass=person))',
+            sorting=[('uid', 'caseIgnoreOrderingMatch', False)],
+        ):
             print(entry.dn, entry.attr)
+
+        # search paginated via VirtualListView + ServerSideSorting
+        async for entry in conn.search_paginated(
+            search_base,
+            Scope.Subtree,
+            '(&(uid=*)(objectClass=person))',
+            page_size=10,
+            sorting=[('uid', 'caseIgnoreOrderingMatch', False)],
+        ):
+            print(entry.dn, entry.attr, entry.page)
 
         # get a certain object, and use its attributes
         obj = await conn.get('uid=max.mustermann,dc=freeiam,dc=org')

--- a/src/freeiam/errors.py
+++ b/src/freeiam/errors.py
@@ -66,9 +66,13 @@ class LdapError(Error):
         return self._errno
 
     @property
-    def controls(self) -> None:
+    def controls(self) -> list | None:
         """List of LDAP Control instances attached to the error."""
-        return self._controls
+        if self._controls_decoded is None:
+            from freeiam.ldap.controls import decode  # noqa: PLC0415
+
+            self._controls_decoded = decode(self._controls)
+        return self._controls_decoded
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -83,6 +87,7 @@ class LdapError(Error):
         self._matched = args.get('matched')
         self._errno = args.get('errno')
         self._controls = args.get('ctrls')
+        self._controls_decoded = None
         super().__init__()
 
     def __str__(self):

--- a/src/freeiam/ldap/_wrapper.py
+++ b/src/freeiam/ldap/_wrapper.py
@@ -42,6 +42,12 @@ class Controls:
         controls.server.append(control)
         return controls
 
+    @classmethod
+    def set_server(cls, controls, control):
+        controls = Controls([]) if controls is None else controls
+        controls.server = [ctrl for ctrl in controls.server if ctrl.controlType != control.controlType] + [control]
+        return controls
+
 
 @dataclass
 class _Response:
@@ -60,7 +66,7 @@ class _Response:
 
 
 @dataclass
-class SimplePage:
+class Page:
     """A page of a paginated search result."""
 
     page: int
@@ -71,6 +77,12 @@ class SimplePage:
 
     page_size: int
     """The number of entries per page."""
+
+    results: int | None = None
+    """The total number of search results."""
+
+    last_page: int | None = None
+    """The last page of all search results."""
 
     @property
     def is_last_in_page(self) -> bool:
@@ -94,7 +106,7 @@ class Result:
     _response: _Response
     """The raw LDAP result."""
 
-    page: SimplePage | None = None
+    page: Page | None = None
     """The page of a paginated search result."""
 
     @classmethod

--- a/src/freeiam/ldap/connection.py
+++ b/src/freeiam/ldap/connection.py
@@ -5,6 +5,7 @@
 import asyncio
 import contextlib
 import logging
+import math
 import os
 from collections.abc import AsyncGenerator, Callable, Generator
 from typing import Any, Self, TypeAlias
@@ -15,10 +16,10 @@ import ldap.sasl
 from ldap.schema import SCHEMA_ATTRS
 
 from freeiam import errors
-from freeiam.ldap._wrapper import Controls, Result, SimplePage, _Response
+from freeiam.ldap._wrapper import Controls, Page, Result, _Response
 from freeiam.ldap.attr import Attributes
 from freeiam.ldap.constants import AnyOption, AnyOptionValue, Option, OptionValue, ResponseType, Scope, TLSOption, TLSOptionValue, Version
-from freeiam.ldap.controls import simple_paged_results
+from freeiam.ldap.controls import server_side_sorting, simple_paged_results, virtual_list_view, virtual_list_view_response
 from freeiam.ldap.dn import DN
 from freeiam.ldap.schema import Schema
 from freeiam.ldap.sync_connection import Connection as SynchronousConnection
@@ -31,6 +32,7 @@ log = logging.getLogger(__name__)
 LDAPObject: TypeAlias = ldap.ldapobject.SimpleLDAPObject
 LDAPAddList: TypeAlias = list[tuple[str, list[bytes]]]
 LDAPModList: TypeAlias = list[tuple[int, str, list[bytes] | None]]
+Sorting: TypeAlias = list[str | tuple[str, str | None, bool]]
 
 
 class Connection:
@@ -420,12 +422,15 @@ class Connection:
         *,
         unique: bool = False,
         sizelimit: bool | None = None,
+        sorting: Sorting | None = None,
         controls: Controls | None = None,
         _attrsonly: bool = False,
     ) -> AsyncGenerator[Result, None]:
         """Search iterative for DN and Attributes of LDAP objects."""
         conn = self.conn
         all_results = []
+        if sorting:
+            controls = Controls.set_server(controls, server_side_sorting(*sorting, criticality=True))
         # sizelimit = 1 if unique else sizelimit
         try:
             async for response in self._execute_iter(
@@ -473,12 +478,15 @@ class Connection:
         *,
         unique: bool = False,
         sizelimit: bool | None = None,
+        sorting: Sorting | None = None,
         controls: Controls | None = None,
         _attrsonly: bool = False,
     ) -> AsyncGenerator[Result, None]:
         """Search for DN and Attributes of LDAP objects."""
         conn = self.conn
         all_results = []
+        if sorting:
+            controls = Controls.set_server(controls, server_side_sorting(*sorting))
         try:
             response = await self._execute(
                 conn,
@@ -513,15 +521,83 @@ class Connection:
         *,
         unique: bool = False,
         sizelimit: bool | None = None,
+        sorting: Sorting | None = None,
         controls: Controls | None = None,
     ) -> AsyncGenerator[DN, None]:
         """Search for DNs of LDAP objects."""
         # FIXME: the following hangs forever as the iterative search is unfinished while the FD reader is replaced
-        # async for result in self.search(base, scope, filter_expr, ['1.1'], unique=unique, sizelimit=sizelimit, controls=controls, _attrsonly=True):
-        for result in await self.search(base, scope, filter_expr, [], unique=unique, sizelimit=sizelimit, controls=controls, _attrsonly=True):
+        # async for result in self.search(
+        #     base, scope, filter_expr, ['1.1'], unique=unique, sizelimit=sizelimit, sorting=sorting, controls=controls, _attrsonly=True
+        # ):
+        for result in await self.search(
+            base, scope, filter_expr, [], unique=unique, sizelimit=sizelimit, sorting=sorting, controls=controls, _attrsonly=True
+        ):
             yield result.dn
 
     async def search_paginated(
+        self,
+        base: DN | str = '',
+        scope: Scope = Scope.SUBTREE,
+        filter_expr: str = '(objectClass=*)',
+        attrs: list[str] | None = None,
+        *,
+        page_size: int = 100,
+        sorting: Sorting,
+        unique: bool = False,
+        sizelimit: bool | None = None,
+        controls: Controls | None = None,
+    ) -> AsyncGenerator[Result, None]:
+        """Search paginated using Virtual List View control."""
+        controls = Controls.set_server(controls, server_side_sorting(*sorting))
+
+        res_vlv = virtual_list_view_response()
+        context_id = None
+        length = None
+        last_page = None
+        page = 1
+        while True:
+            offset = ((page or 1) - 1) * page_size
+            pagination = virtual_list_view(
+                before_count=0,
+                after_count=page_size - 1,
+                offset=offset + 1,
+                content_count=0,
+                greater_than_or_equal=None,
+                context_id=context_id,
+                criticality=True,
+            )
+            controls = Controls.set_server(controls, pagination)
+            if length is not None and offset > length:
+                break  # end reached
+
+            vlv = None
+            current = None
+            for entry_number, result in enumerate(
+                await self.search(base, scope, filter_expr, attrs, unique=unique, sizelimit=sizelimit, controls=controls), 1
+            ):
+                if last_page is None:
+                    vlv = controls.get(res_vlv)
+                    length = vlv.contentCount
+                    last_page = math.ceil(length / (page_size or length))
+                result.page = Page(
+                    page=page,
+                    entry=entry_number,
+                    page_size=page_size,
+                    results=length,
+                    last_page=last_page,
+                )
+                current = result
+                yield result
+
+            if current is None:  # no search results
+                break
+
+            page += 1
+            vlv = controls.get(res_vlv)
+            context_id = vlv.context_id
+            length = vlv.contentCount
+
+    async def search_paged(
         self,
         base: DN | str = '',
         scope: Scope = Scope.SUBTREE,
@@ -531,11 +607,14 @@ class Connection:
         *,
         unique: bool = False,
         sizelimit: bool | None = None,
+        sorting: Sorting | None = None,
         controls: Controls | None = None,
     ) -> AsyncGenerator[Result, None]:
         """Search paginated using SimplePagedResults control."""
         pagination = simple_paged_results(size=page_size, cookie='', criticality=True)
         controls = Controls.append_server(controls, pagination)
+        if sorting:
+            controls = Controls.set_server(controls, server_side_sorting(*sorting))
         page = 0
         while True:
             current = None
@@ -543,7 +622,7 @@ class Connection:
             entry_number = 0
             async for result in self.search_iter(base, scope, filter_expr, attrs, unique=unique, sizelimit=sizelimit, controls=controls):
                 entry_number += 1
-                result.page = SimplePage(page=page, entry=entry_number, page_size=page_size)
+                result.page = Page(page=page, entry=entry_number, page_size=page_size)
                 current = result
                 yield result
 

--- a/src/freeiam/ldap/connection.py
+++ b/src/freeiam/ldap/connection.py
@@ -534,7 +534,7 @@ class Connection:
         controls: Controls | None = None,
     ) -> AsyncGenerator[Result, None]:
         """Search paginated using SimplePagedResults control."""
-        pagination = simple_paged_results(criticality=True, size=page_size, cookie='')
+        pagination = simple_paged_results(size=page_size, cookie='', criticality=True)
         controls = Controls.append_server(controls, pagination)
         page = 0
         while True:

--- a/src/freeiam/ldap/controls.py
+++ b/src/freeiam/ldap/controls.py
@@ -2,12 +2,48 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 """LDAP Server and Client controls."""
 
-from ldap.controls import SimplePagedResultsControl
+from ldap.controls import DecodeControlTuples, ResponseControl
+from ldap.controls.pagedresults import SimplePagedResultsControl
+from ldap.controls.sss import SSSRequestControl
+from ldap.controls.vlv import VLVRequestControl
 
 
 __all__ = ('simple_paged_results',)
 
 
-def simple_paged_results(*args, **kwargs):
+def decode(ctrls: list[tuple[str, int, bytes]]) -> list[ResponseControl]:
+    return DecodeControlTuples(ctrls)
+
+
+def simple_paged_results(size=10, cookie='', *, criticality=False):
     """SimplePagedResults control."""
-    return SimplePagedResultsControl(*args, **kwargs)
+    return SimplePagedResultsControl(criticality, size, cookie)
+
+
+def server_side_sorting(
+    *ordering_rules: str | tuple[str, str | None, bool],
+    criticality=False,
+):
+    """Server Side Sorting."""
+    ordering_rules_ = []
+    for rule in ordering_rules:
+        if not isinstance(rule, str):
+            by, matchingrule, reverse = rule
+            ordering_rules_.append('{}{}{}{}'.format('-' if reverse else '', by, ':' if matchingrule else '', matchingrule))
+            continue
+        ordering_rules_.append(rule)
+    return SSSRequestControl(criticality, ordering_rules_)
+
+
+def virtual_list_view(
+    before_count=0,
+    after_count=0,
+    offset=None,
+    content_count=None,
+    greater_than_or_equal=None,
+    context_id=None,
+    *,
+    criticality=False,
+):
+    """Virtual List View."""
+    return VLVRequestControl(criticality, before_count, after_count, offset, content_count, greater_than_or_equal, context_id)

--- a/src/freeiam/ldap/controls.py
+++ b/src/freeiam/ldap/controls.py
@@ -5,7 +5,7 @@
 from ldap.controls import DecodeControlTuples, ResponseControl
 from ldap.controls.pagedresults import SimplePagedResultsControl
 from ldap.controls.sss import SSSRequestControl
-from ldap.controls.vlv import VLVRequestControl
+from ldap.controls.vlv import VLVRequestControl, VLVResponseControl
 
 
 __all__ = ('simple_paged_results',)
@@ -47,3 +47,7 @@ def virtual_list_view(
 ):
     """Virtual List View."""
     return VLVRequestControl(criticality, before_count, after_count, offset, content_count, greater_than_or_equal, context_id)
+
+
+def virtual_list_view_response():
+    return VLVResponseControl()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,22 @@ def _ldap_server():
         .with_env('LDAP_CONFIG_ADMIN_ENABLED', 'yes')
         .with_env('LDAP_CONFIG_PASSWORD', CONFIG_ADMIN_PW)
         .with_env('LDAP_PASSWORDS', 'iamfree1,iamfree2')
-        .with_env('LDAP_LOGLEVEL', '245')
+        # 1      (0x1 trace) trace function calls
+        # 2      (0x2 packets) debug packet handling
+        # 4      (0x4 args) heavy trace debugging (function args)
+        # 8      (0x8 conns) connection management
+        # 16     (0x10 BER) print out packets sent and received
+        # 32     (0x20 filter) search filter processing
+        # 64     (0x40 config) configuration file processing
+        # 128    (0x80 ACL) access control list processing
+        # 256    (0x100 stats) connections, LDAP operations, results (recommended)
+        # 512    (0x200 stats2) stats2 log entries sent
+        # 1024   (0x400 shell) print communication with shell backends
+        # 2048   (0x800 parse) entry parsing
+        # 16384  (0x4000 sync) LDAPSync replication
+        # 32768  (0x8000 none) only messages that get logged whatever log level is set
+        # .with_env('LDAP_LOGLEVEL', str(0x1 | 0x4 | 0x100 | 0x200))  # stats stats2 args trace
+        .with_env('LDAP_LOGLEVEL', '256')
         .with_env('LDAP_PASSWORD_HASH', '{CRYPT}')
         .with_env('LDAP_CONFIGURE_PPOLICY', 'yes')
         .with_env('LDAP_ENABLE_TLS', 'yes')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,6 +230,7 @@ def _ldap_server():
         .with_env('LDAP_TLS_DH_PARAMS_FILE', '/opt/bitnami/openldap/certs/dhparam.pem')
         .with_env('LDAP_TLS_VERIFY_CLIENT', 'never')
         .with_volume_mapping(str(cert_dir_copy), '/opt/bitnami/openldap/certs', mode='rw')
+        .with_volume_mapping(str(Path.cwd() / 'tests/entrypoint/'), '/docker-entrypoint-initdb.d/', mode='ro')
     )
     container_.start()
     container = container_

--- a/tests/entrypoint/sssvlv.sh
+++ b/tests/entrypoint/sssvlv.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 Broadcom
+# SPDX-License-Identifier: Apache-2.0
+# Script to enable sssvlv overlay in OpenLDAP
+set -e
+
+cat > /tmp/sssvlv-overlay.ldif << 'EOF'
+dn: cn=module{1},cn=config
+objectClass: olcModuleList
+cn: module{1}
+olcModuleLoad: sssvlv
+
+dn: olcOverlay=sssvlv,olcDatabase={2}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcSssVlvConfig
+olcOverlay: sssvlv
+olcSssVlvMax: 100
+olcSssVlvMaxKeys: 20
+EOF
+
+echo "Enabling sssvlv overlay in OpenLDAP configuration..."
+if slapcat -F /opt/bitnami/openldap/etc/slapd.d -b cn=config | grep -q sssvlv
+then
+    echo "SSS VLV overlay is already configured."
+    exit 0
+else
+    slapadd -F /opt/bitnami/openldap/etc/slapd.d -b cn=config -l /tmp/sssvlv-overlay.ldif || {
+        echo "NOTICE: slapadd failed to load sssvlv overlay. Check the cn=module{N} with \"slapcat -F /opt/bitnami/openldap/etc/slapd.d -b cn=config |grep 'cn=module'\""
+        exit 1
+    }
+fi
+
+echo "SSS VLV overlay has been configured."

--- a/tests/test_ldap_connection.py
+++ b/tests/test_ldap_connection.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import inspect
 import logging
+import math
 import pickle
 
 import ldap as _ldap
@@ -9,7 +10,9 @@ import pytest
 import pytest_asyncio
 
 from freeiam import errors, ldap
+from freeiam.ldap._wrapper import Controls  # noqa: PLC2701
 from freeiam.ldap.constants import Dereference, Option, OptionValue, Scope, TLSOptionValue, Version
+from freeiam.ldap.controls import virtual_list_view, virtual_list_view_response
 
 
 log = logging.getLogger(__name__)
@@ -265,6 +268,23 @@ async def test_search(conn, testuser, base_dn):
 
 
 @pytest.mark.asyncio
+async def test_sorting_search(conn, testuser, base_dn):
+    filter_s = f'(cn={TESTUSERNAME}*)'
+    result = list(reversed([entry async for entry in conn.search_dn(base_dn, Scope.SUBTREE, filter_s)]))
+    sresult = [entry.dn async for entry in conn.search_iter(base_dn, Scope.SUBTREE, filter_s, sorting=[('cn', 'caseIgnoreOrderingMatch', True)])]
+    assert result == sresult
+
+    sresult2 = [entry.dn for entry in await conn.search(base_dn, Scope.SUBTREE, filter_s, sorting=[('cn', 'caseIgnoreOrderingMatch', True)])]
+    assert result == sresult2
+
+    sresult3 = [entry async for entry in conn.search_dn(base_dn, Scope.SUBTREE, filter_s, sorting=['-cn:caseIgnoreOrderingMatch'])]
+    assert result == sresult3
+
+    sresult4 = [entry.dn async for entry in conn.search_paged(base_dn, Scope.SUBTREE, filter_s, sorting=[('cn', 'caseIgnoreOrderingMatch', True)])]
+    assert result == sresult4
+
+
+@pytest.mark.asyncio
 async def test_modify(conn, testuser):
     dn, attrs = testuser
 
@@ -401,16 +421,10 @@ async def test_duplicated_unbind(conn):
     assert not (await conn.whoami())
 
 
-@pytest.mark.asyncio
-async def test_paginated_search_expect_nothing(conn, base_dn):
-    async for entry in conn.search_paginated(base_dn, Scope.SUBTREE, '(cn=doesnotexists)', page_size=5):
-        pytest.fail(f'Got {entry}')
-
-
 @pytest_asyncio.fixture(scope='session')
 async def page_users(sess_conn, base_dn):
     results = []
-    for i in range(1, NUM_PAGEUSERS):
+    for i in range(1, NUM_PAGEUSERS + 1):
         dn = f'cn={PAGEPREFIX}user{i},{base_dn}'
         await create_user(sess_conn, dn, sn='User')
         results.append(dn)
@@ -419,17 +433,22 @@ async def page_users(sess_conn, base_dn):
 
 @pytest.mark.asyncio
 async def test_paginated_search(conn, page_users, base_dn):
-    results = list(page_users)
-    page_size = 5
+    results = sorted(page_users)
+    page_size = 6
+    total_pages = math.ceil(len(results) / page_size)
     total_entries = 0
     cur_entry_on_page = 1
-    async for entry in conn.search_paginated(base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', page_size=page_size):
+    async for entry in conn.search_paginated(
+        base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', page_size=page_size, sorting=[('cn', 'caseIgnoreOrderingMatch', False)]
+    ):
         assert results.pop(0) == entry.dn
 
         assert entry.page.page_size == page_size
         assert entry.page.page == (1 + total_entries // page_size)
         assert entry.page.is_last_in_page == (page_size == entry.page.entry)
         assert entry.page.entry == cur_entry_on_page
+        assert entry.page.results == NUM_PAGEUSERS
+        assert entry.page.last_page is total_pages
 
         total_entries += 1
         cur_entry_on_page += 1
@@ -437,7 +456,67 @@ async def test_paginated_search(conn, page_users, base_dn):
             cur_entry_on_page = 1
 
     assert not results, results
-    assert total_entries + 1 == NUM_PAGEUSERS
+    assert total_entries == NUM_PAGEUSERS
+
+
+@pytest.mark.asyncio
+async def test_paginated_error_search(conn, page_users, base_dn):
+    pagination = virtual_list_view(
+        before_count=0,
+        after_count=100,
+        offset=0,
+        content_count=0,
+        greater_than_or_equal=None,
+        context_id=None,
+        criticality=True,
+    )
+    controls = Controls.set_server(None, pagination)
+    await conn.search(base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', sorting=[('cn', 'caseIgnoreOrderingMatch', False)], controls=controls)
+    res = controls.get(virtual_list_view_response())
+    pagination.context_id = res.context_id
+    pagination.offset = res.contentCount + 1
+    with pytest.raises(errors.VLVError) as exc:
+        await conn.search(base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', sorting=[('cn', 'caseIgnoreOrderingMatch', False)], controls=controls)
+    assert exc.value.controls[0].result == 77  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_paginated_search_expect_nothing(conn, base_dn):
+    async for entry in conn.search_paginated(
+        base_dn, Scope.SUBTREE, '(cn=doesnotexists)', page_size=5, sorting=[('cn', 'caseIgnoreOrderingMatch', False)]
+    ):
+        pytest.fail(f'Got {entry}')
+
+
+@pytest.mark.asyncio
+async def test_paged_search(conn, page_users, base_dn):
+    results = list(page_users)
+    page_size = 5
+    total_entries = 0
+    cur_entry_on_page = 1
+    async for entry in conn.search_paged(base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', page_size=page_size):
+        assert results.pop(0) == entry.dn
+
+        assert entry.page.page_size == page_size
+        assert entry.page.page == (1 + total_entries // page_size)
+        assert entry.page.is_last_in_page == (page_size == entry.page.entry)
+        assert entry.page.entry == cur_entry_on_page
+        assert entry.page.results is None
+        assert entry.page.last_page is None
+
+        total_entries += 1
+        cur_entry_on_page += 1
+        if entry.page.is_last_in_page:
+            cur_entry_on_page = 1
+
+    assert not results, results
+    assert total_entries == NUM_PAGEUSERS
+
+
+@pytest.mark.asyncio
+async def test_paged_search_expect_nothing(conn, base_dn):
+    async for entry in conn.search_paged(base_dn, Scope.SUBTREE, '(cn=doesnotexists)', page_size=5):
+        pytest.fail(f'Got {entry}')
 
 
 @pytest.mark.asyncio
@@ -596,7 +675,20 @@ async def test_change_password(ldap_server, conn, base_dn):
 
 @pytest.mark.asyncio
 async def test_paginated_search_close(conn, page_users, base_dn):
-    gen = conn.search_paginated(base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', page_size=1)
+    gen = conn.search_paginated(base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', page_size=1, sorting=[('uid', 'caseIgnoreOrderingMatch', False)])
+
+    result = await anext(gen)
+    assert result is not None
+
+    await gen.aclose()
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+
+@pytest.mark.asyncio
+async def test_paged_search_close(conn, page_users, base_dn):
+    gen = conn.search_paged(base_dn, Scope.SUBTREE, f'(cn={PAGEPREFIX}*)', page_size=1)
 
     result = await anext(gen)
     assert result is not None

--- a/tests/test_ldap_various.py
+++ b/tests/test_ldap_various.py
@@ -1,7 +1,8 @@
+import ldap as _ldap
 import pytest_asyncio
 from ldap.controls import RelaxRulesControl, SimplePagedResultsControl
 
-from freeiam import ldap
+from freeiam import errors, ldap
 from freeiam.ldap._wrapper import Controls, Result  # noqa: PLC2701
 
 
@@ -16,6 +17,23 @@ def test_result_control_empty():
 
     result = Result('', {}, Controls(None, None, [ctrl]), None)
     assert result.controls.get(RelaxRulesControl()) is None
+
+
+def test_exception_controls():
+    exc = errors.VLVError(
+        _ldap.VLV_ERROR(
+            {
+                'msgtype': 101,
+                'msgid': 5,
+                'result': 76,
+                'desc': 'Virtual List View error',
+                'ctrls': [('2.16.840.1.113730.3.4.10', 0, b'0\x13\x02\x01\x00\x02\x01\x0b\n\x01M\x04\x08 ]\x10\x94\xad\x7f\x00\x00')],
+            }
+        )
+    )
+    ctrls = exc.controls
+    assert ctrls
+    assert ctrls is exc.controls
 
 
 @pytest_asyncio.fixture(scope='function')


### PR DESCRIPTION
```python
        async for entry in conn.search_paginates(
            search_base,
            Scope.Subtree,
            '(&(uid=*)(objectClass=person))',
            page_size=10,
            sorting=[('uid', 'caseIgnoreOrderingMatch', False)],
        ):
            print(entry.dn, entry.attr, entry.page)
```
