### PR TITLE
ci(tests): update test container to bitnamilegacy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,7 +197,7 @@ def _ldap_server():
     shutil.copytree(cert_dir, cert_dir_copy)
 
     container_ = (
-        DockerContainer('bitnami/openldap:2.4')
+        DockerContainer('bitnamilegacy/openldap:2.4')
         .with_exposed_ports(1389, 1636)
         .with_env('LDAP_ORGANISATION', ORGANISATION)
         .with_env('LDAP_ROOT', BASE_DN)


### PR DESCRIPTION
as bitnami dropped support for non-commercial OpenLDAP